### PR TITLE
refactor: use `useSyncExternalStore` pattern

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,6 @@
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypeScript from "eslint-config-next/typescript";
 
-const eslintConfig = [
-  ...nextCoreWebVitals,
-  ...nextTypeScript,
-  {
-    files: [
-      "src/app/components/CanvasViewer.tsx",
-      "src/features/events/components/EventClips.tsx",
-    ],
-    rules: {
-      "react-hooks/set-state-in-effect": "off",
-    },
-  },
-];
+const eslintConfig = [...nextCoreWebVitals, ...nextTypeScript];
 
 export default eslintConfig;

--- a/src/app/components/CanvasViewer.tsx
+++ b/src/app/components/CanvasViewer.tsx
@@ -1,5 +1,11 @@
 "use client";
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
 import Image from "next/image";
 
 interface CanvasViewerProps {
@@ -11,21 +17,21 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
   const [transformOrigin, setTransformOrigin] = useState("center center");
   // const [cursorPos, setCursorPos] = useState({ x: 0, y: 0 });
   // const [showCoords, setShowCoords] = useState(false);
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const zoomLevel = 4;
 
-  // Detect touch device
-  useEffect(() => {
-    setIsTouchDevice(
-      "ontouchstart" in window ||
+  const isTouchDevice = useSyncExternalStore(
+    () => () => {}, // No subscription needed; touch capability doesn't change
+    () =>
+      typeof window !== "undefined" &&
+      ("ontouchstart" in window ||
         navigator.maxTouchPoints > 0 ||
         ("msMaxTouchPoints" in navigator &&
-          (navigator as Navigator).maxTouchPoints > 0),
-    );
-  }, []);
+          (navigator as Navigator).maxTouchPoints > 0)),
+    () => false, // Server-side: assume no touch
+  );
 
   // Prevent scroll on page when zoomed
   useEffect(() => {
@@ -102,9 +108,9 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
     }, 150); // Same duration as the CSS transition
   }, []);
 
+  // Desktop-specific event listener for mouse-up outside the container
   useEffect(() => {
-    // Only needed for desktop when zoomed
-    if (isZoomed && !isTouchDevice) {
+    if (isZoomed) {
       const handleGlobalMouseUp = () => {
         resetZoom();
       };
@@ -115,7 +121,7 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
         document.removeEventListener("mouseup", handleGlobalMouseUp);
       };
     }
-  }, [isZoomed, isTouchDevice, resetZoom]);
+  }, [isZoomed, resetZoom]);
 
   // // Calculate image coordinates from pointer position
   // const calculateImageCoords = (clientX: number, clientY: number) => {
@@ -190,7 +196,7 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
   const handlePointerUp = () => {
     if (isTouchDevice) return;
 
-    if (!isTouchDevice && isZoomed) {
+    if (isZoomed) {
       resetZoom();
     }
   };

--- a/src/app/components/CanvasViewer.tsx
+++ b/src/app/components/CanvasViewer.tsx
@@ -1,10 +1,5 @@
 "use client";
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-} from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import { useStaticBrowserValue } from "@/lib/useStaticBrowserValue";
 
@@ -18,8 +13,7 @@ const getTouchDeviceSnapshot = () =>
     navigator.maxTouchPoints > 0 ||
     ("msMaxTouchPoints" in navigator &&
       ((navigator as Navigator & { msMaxTouchPoints?: number })
-        .msMaxTouchPoints ??
-        0) > 0));
+        .msMaxTouchPoints ?? 0) > 0));
 
 const getTouchDeviceServerSnapshot = () => false;
 
@@ -113,9 +107,9 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
     }, 150); // Same duration as the CSS transition
   }, []);
 
-  // Desktop-specific event listener for mouse-up outside the container
   useEffect(() => {
-    if (isZoomed) {
+    // Only needed for desktop when zoomed
+    if (isZoomed && !isTouchDevice) {
       const handleGlobalMouseUp = () => {
         resetZoom();
       };
@@ -126,7 +120,7 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
         document.removeEventListener("mouseup", handleGlobalMouseUp);
       };
     }
-  }, [isZoomed, resetZoom]);
+  }, [isZoomed, isTouchDevice, resetZoom]);
 
   // // Calculate image coordinates from pointer position
   // const calculateImageCoords = (clientX: number, clientY: number) => {
@@ -201,7 +195,7 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
   const handlePointerUp = () => {
     if (isTouchDevice) return;
 
-    if (isZoomed) {
+    if (!isTouchDevice && isZoomed) {
       resetZoom();
     }
   };

--- a/src/app/components/CanvasViewer.tsx
+++ b/src/app/components/CanvasViewer.tsx
@@ -17,7 +17,9 @@ const getTouchDeviceSnapshot = () =>
   ("ontouchstart" in window ||
     navigator.maxTouchPoints > 0 ||
     ("msMaxTouchPoints" in navigator &&
-      (navigator as Navigator).maxTouchPoints > 0));
+      ((navigator as Navigator & { msMaxTouchPoints?: number })
+        .msMaxTouchPoints ??
+        0) > 0));
 
 const getTouchDeviceServerSnapshot = () => false;
 

--- a/src/app/components/CanvasViewer.tsx
+++ b/src/app/components/CanvasViewer.tsx
@@ -4,13 +4,22 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useSyncExternalStore,
 } from "react";
 import Image from "next/image";
+import { useStaticBrowserValue } from "@/lib/useStaticBrowserValue";
 
 interface CanvasViewerProps {
   canvasImageUrl: string;
 }
+
+const getTouchDeviceSnapshot = () =>
+  typeof window !== "undefined" &&
+  ("ontouchstart" in window ||
+    navigator.maxTouchPoints > 0 ||
+    ("msMaxTouchPoints" in navigator &&
+      (navigator as Navigator).maxTouchPoints > 0));
+
+const getTouchDeviceServerSnapshot = () => false;
 
 const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
   const [isZoomed, setIsZoomed] = useState(false);
@@ -22,15 +31,9 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ canvasImageUrl }) => {
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const zoomLevel = 4;
 
-  const isTouchDevice = useSyncExternalStore(
-    () => () => {}, // No subscription needed; touch capability doesn't change
-    () =>
-      typeof window !== "undefined" &&
-      ("ontouchstart" in window ||
-        navigator.maxTouchPoints > 0 ||
-        ("msMaxTouchPoints" in navigator &&
-          (navigator as Navigator).maxTouchPoints > 0)),
-    () => false, // Server-side: assume no touch
+  const isTouchDevice = useStaticBrowserValue(
+    getTouchDeviceSnapshot,
+    getTouchDeviceServerSnapshot,
   );
 
   // Prevent scroll on page when zoomed

--- a/src/features/events/components/EventClips.tsx
+++ b/src/features/events/components/EventClips.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import React, { useSyncExternalStore } from "react";
+import { useStaticBrowserValue } from "@/lib/useStaticBrowserValue";
 
 interface EventClipsProps {
   clips: string[];
 }
 
+const getHostSnapshot = () =>
+  typeof window !== "undefined" ? window.location.hostname : null;
+
+const getHostServerSnapshot = () => null;
+
 const EventClips = ({ clips }: EventClipsProps) => {
-  const host = useSyncExternalStore(
-    () => () => {}, // No subscription needed; hostname doesn't change during session
-    () => (typeof window !== "undefined" ? window.location.hostname : null),
-    () => null, // Server-side: no hostname available
+  const host = useStaticBrowserValue(
+    getHostSnapshot,
+    getHostServerSnapshot,
   );
 
   if (clips.length === 0) {

--- a/src/features/events/components/EventClips.tsx
+++ b/src/features/events/components/EventClips.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useSyncExternalStore } from "react";
 
 interface EventClipsProps {
   clips: string[];
 }
 
 const EventClips = ({ clips }: EventClipsProps) => {
-  const [host, setHost] = useState<string | null>(null);
-
-  useEffect(() => {
-    setHost(window.location.hostname);
-  }, []);
+  const host = useSyncExternalStore(
+    () => () => {}, // No subscription needed; hostname doesn't change during session
+    () => (typeof window !== "undefined" ? window.location.hostname : null),
+    () => null, // Server-side: no hostname available
+  );
 
   if (clips.length === 0) {
     return null;

--- a/src/lib/useStaticBrowserValue.ts
+++ b/src/lib/useStaticBrowserValue.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribeToStaticValue = () => () => {};
+
+export function useStaticBrowserValue<T>(
+  getSnapshot: () => T,
+  getServerSnapshot: () => T,
+): T {
+  return useSyncExternalStore(
+    subscribeToStaticValue,
+    getSnapshot,
+    getServerSnapshot,
+  );
+}


### PR DESCRIPTION
Replacing `useState` + `useEffect` with `useSyncExternalStore` for CanvasViewer detecting touch device abilities and EventClips reading browser hostname.

`useSyncExternalStore` is the correct API for reading external state that doesn't change during the component lifecycle. This removes the anti pattern of calling `setState` inside effects, which can cause unnecessary render passes.